### PR TITLE
Minor improvements in dealing with empty floats

### DIFF
--- a/csv2parquet/csv2parquet.py
+++ b/csv2parquet/csv2parquet.py
@@ -145,8 +145,8 @@ def convert(csv_file, output_file, row_group_size, codec, max_rows,
                             dropped_value_examples[idx].append(str(value))
                         value = None
                     else:
-                        raise ValueError('unexpected value for column {}, type {}: {}'
-                                         .format(column_names[idx], expected_type, str(value)))
+                        raise ValueError('unexpected value for column {}, type {}: {} on row {}'
+                                         .format(column_names[idx], expected_type, str(value), rownum))
                 except IndexError:
                     raise IndexError('Too many columns {} for row {}'.format(idx, rownum))
 

--- a/csv2parquet/csv2parquet.py
+++ b/csv2parquet/csv2parquet.py
@@ -114,7 +114,10 @@ def convert(csv_file, output_file, row_group_size, codec, max_rows,
                         else:
                             raise ValueError()
                     elif expected_type in (PA_FLOAT32, PA_FLOAT64):
-                        value = float(value)
+                        if "".__eq__(value):
+                            value = float('nan')      
+                        else:
+                            value = float(value)
                     elif expected_type == PA_INT8:
                         value = int(value)
                         if value < -128 or value > 127:


### PR DESCRIPTION
Dealing with a 69M row CSV that has a column that I've set as a float.  Occasionally there are rows with empty values which was throwing a ValueError.  This PR add debugging info as well as allowing these empty values to be replaced with a NAN instead.